### PR TITLE
Load entities even when device is offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 pipfile
 pipfile.lock
 .idea
+/config.yaml

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ If you encounter issues:
 
 ## Known Issues
 
-- **Adding devices that are offline**: If you add a device that is offline, it will not add all the entities. You will need to reload the integration manually
 - **Logging in in the App**: The login process in the app will log out any existing sessions (at least on Android). If you log in the app, reload the integration.
 
 > [!NOTE]

--- a/custom_components/aux_cloud/__init__.py
+++ b/custom_components/aux_cloud/__init__.py
@@ -20,7 +20,7 @@ from .const import (
     CONF_SELECTED_DEVICES,
 )
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=180)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 # Schema to include email and password (device selection is handled in config flow)
 CONFIG_SCHEMA = vol.Schema(

--- a/custom_components/aux_cloud/api/aux_cloud.py
+++ b/custom_components/aux_cloud/api/aux_cloud.py
@@ -8,7 +8,7 @@ from typing import TypedDict
 
 import aiohttp
 
-from custom_components.aux_cloud.api.const import AUX_MODEL_TO_PARAMS
+from custom_components.aux_cloud.api.const import AUX_MODEL_SPECIAL_PARAMS_LIST
 from custom_components.aux_cloud.api.util import encrypt_aes_cbc_zero_padding
 
 TIMESTAMP_TOKEN_ENCRYPT_KEY = "kdixkdqp54545^#*"
@@ -325,14 +325,15 @@ class AuxCloudAPI:
                 dev_params_task = self.get_device_params(dev, params=list([]))
                 dev_special_params_task = None
 
-                if dev["productId"] in AUX_MODEL_TO_PARAMS:
+                if dev["productId"] in AUX_MODEL_SPECIAL_PARAMS_LIST:
                     _LOGGER.debug(
                         "Fetching special params for device %s: %s",
                         dev["productId"],
-                        AUX_MODEL_TO_PARAMS[dev["productId"]],
+                        AUX_MODEL_SPECIAL_PARAMS_LIST[dev["productId"]],
                     )
                     dev_special_params_task = self.get_device_params(
-                        dev, params=list(AUX_MODEL_TO_PARAMS[dev["productId"]])
+                        dev,
+                        params=list(AUX_MODEL_SPECIAL_PARAMS_LIST[dev["productId"]]),
                     )
 
                 # Add tasks to the list

--- a/custom_components/aux_cloud/api/const.py
+++ b/custom_components/aux_cloud/api/const.py
@@ -1,11 +1,5 @@
 from enum import auto
 
-# Used to fetch params from the device that are not returned in basic call
-AUX_MODEL_TO_PARAMS = {
-    "000000000000000000000000c0620000": ["mode"],
-    "000000000000000000000000c3aa0000": ["hp_water_tank_temp"],
-}
-
 AUX_MODEL_TO_NAME = {
     "000000000000000000000000c3aa0000": "AUX Heat Pump",
     "000000000000000000000000c0620000": "AUX Air Conditioner",
@@ -23,11 +17,6 @@ class AuxProductCategory(auto):
 
 # Common constants
 AUX_MODE = "ac_mode"
-AUX_MODE_COOLING = {AUX_MODE: 0}
-AUX_MODE_HEATING = {AUX_MODE: 1}
-AUX_MODE_DRY = {AUX_MODE: 2}
-AUX_MODE_FAN = {AUX_MODE: 3}
-AUX_MODE_AUTO = {AUX_MODE: 4}
 
 AUX_ECOMODE = "ecomode"
 AUX_ECOMODE_OFF = {AUX_ECOMODE: 0}
@@ -41,6 +30,12 @@ AC_POWER_ON = {AC_POWER: 1}
 
 AC_TEMPERATURE_TARGET = "temp"
 AC_TEMPERATURE_AMBIENT = "envtemp"
+
+AC_MODE_COOLING = {AUX_MODE: 0}
+AC_MODE_HEATING = {AUX_MODE: 1}
+AC_MODE_DRY = {AUX_MODE: 2}
+AC_MODE_FAN = {AUX_MODE: 3}
+AC_MODE_AUTO = {AUX_MODE: 4}
 
 AC_SWING_VERTICAL = "ac_vdir"
 AC_SWING_VERTICAL_ON = {AC_SWING_VERTICAL: 1}
@@ -87,6 +82,11 @@ AC_POWER_LIMIT_SWITCH = "pwrlimitswitch"
 AC_POWER_LIMIT_OFF = {AC_POWER_LIMIT: 0}
 AC_POWER_LIMIT_ON = {AC_POWER_LIMIT: 1}
 
+# This is a special parameter that allows for fetching envtemp from the AC
+AC_MODE_SPECIAL = "mode"
+
+AC_FAN_SPEED = "ac_mark"
+
 
 class ACFanSpeed(auto):
     PARAM_NAME = "ac_mark"
@@ -103,6 +103,10 @@ class ACFanSpeed(auto):
 
 
 # Heat Pump constants
+HP_MODE_AUTO = {AUX_MODE: 0}
+HP_MODE_COOLING = {AUX_MODE: 1}
+HP_MODE_HEATING = {AUX_MODE: 4}
+
 HP_HEATER_POWER = "ac_pwr"
 HP_HEATER_POWER_OFF = {HP_HEATER_POWER: 0}
 HP_HEATER_POWER_ON = {HP_HEATER_POWER: 1}
@@ -125,6 +129,55 @@ HP_HOT_WATER_TEMPERATURE_TARGET = "hp_hotwater_temp"
 HP_WATER_FAST_HOTWATER = "hp_fast_hotwater"
 HP_WATER_FAST_HOTWATER_ON = {HP_WATER_FAST_HOTWATER: 1}
 HP_WATER_FAST_HOTWATER_OFF = {HP_WATER_FAST_HOTWATER: 0}
+
+
+AUX_MODEL_PARAMS_LIST = {
+    "000000000000000000000000c3aa0000": [
+        "ac_errcode1",
+        AUX_MODE,
+        HP_HEATER_POWER,
+        HP_HEATER_TEMPERATURE_TARGET,
+        AUX_ECOMODE,
+        AUX_ERROR_FLAG,
+        HP_HEATER_AUTO_WATER_TEMP,
+        HP_WATER_FAST_HOTWATER,
+        HP_HOT_WATER_TEMPERATURE_TARGET,
+        HP_WATER_POWER,
+        HP_QUIET_MODE,
+    ],
+    "000000000000000000000000c0620000": [
+        AC_AUXILIARY_HEAT,
+        AC_CLEAN,
+        AC_SWING_HORIZONTAL,
+        AC_HEALTH,
+        AC_FAN_SPEED,
+        AUX_MODE,
+        AC_SLEEP,
+        AC_SWING_VERTICAL,
+        AUX_ECOMODE,
+        AUX_ERROR_FLAG,
+        AC_MILDEW_PROOF,
+        AC_POWER,
+        AC_SCREEN_DISPLAY,
+        AC_TEMPERATURE_TARGET,
+        AC_TEMPERATURE_AMBIENT,
+        AC_POWER_LIMIT,
+        AC_POWER_LIMIT_SWITCH,
+        "new_type",
+        "ac_tempconvert",
+        "sleepdiy",
+        "ac_errcode1",
+        "tempunit",
+        "tenelec",  # Unknown, might be available when the device is in specific state
+    ],
+}
+
+# Used to fetch params from the device that are not returned in basic call
+AUX_MODEL_SPECIAL_PARAMS_LIST = {
+    "000000000000000000000000c3aa0000": [HP_HOT_WATER_TANK_TEMPERATURE],
+    "000000000000000000000000c0620000": [AC_MODE_SPECIAL],
+}
+
 
 """
 AC PARAMETERS NOT TESTED ALL

--- a/custom_components/aux_cloud/api/const.py
+++ b/custom_components/aux_cloud/api/const.py
@@ -163,6 +163,8 @@ AUX_MODEL_PARAMS_LIST = {
         AC_TEMPERATURE_AMBIENT,
         AC_POWER_LIMIT,
         AC_POWER_LIMIT_SWITCH,
+        AC_CHILD_LOCK,
+        AC_COMFORTABLE_WIND,
         "new_type",
         "ac_tempconvert",
         "sleepdiy",

--- a/custom_components/aux_cloud/climate.py
+++ b/custom_components/aux_cloud/climate.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.aux_cloud.api.const import (
+    AC_FAN_SPEED,
     AUX_MODE,
     AC_SWING_HORIZONTAL,
     AC_SWING_HORIZONTAL_OFF,
@@ -32,11 +33,11 @@ from custom_components.aux_cloud.api.const import (
     AC_SWING_VERTICAL_ON,
     AC_TEMPERATURE_AMBIENT,
     AC_TEMPERATURE_TARGET,
+    HP_MODE_COOLING,
+    HP_MODE_HEATING,
     AuxProductCategory,
     AUX_ECOMODE_OFF,
     AUX_ECOMODE_ON,
-    AUX_MODE_COOLING,
-    AUX_MODE_HEATING,
     HP_HEATER_TEMPERATURE_TARGET,
     HP_HEATER_POWER,
     HP_HEATER_POWER_OFF,
@@ -52,7 +53,7 @@ from .const import (
     DOMAIN,
     FAN_MODE_HA_TO_AUX,
     FAN_MODE_AUX_TO_HA,
-    MODE_MAP_AUX_TO_HA,
+    MODE_MAP_AUX_AC_TO_HA,
     MODE_MAP_HA_TO_AUX,
     _LOGGER,
 )
@@ -156,9 +157,9 @@ class AuxHeatPumpClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         if hvac_mode == HVACMode.OFF:
             params = HP_HEATER_POWER_OFF
         elif hvac_mode == HVACMode.HEAT:
-            params = {**AUX_MODE_HEATING, **HP_HEATER_POWER_ON}
+            params = {**HP_MODE_HEATING, **HP_HEATER_POWER_ON}
         elif hvac_mode == HVACMode.COOL:
-            params = {**AUX_MODE_COOLING, **HP_HEATER_POWER_ON}
+            params = {**HP_MODE_COOLING, **HP_HEATER_POWER_ON}
         else:
             return
 
@@ -227,7 +228,7 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
             | ClimateEntityFeature.TURN_ON
             | ClimateEntityFeature.TURN_OFF
         )
-        self._attr_hvac_modes = [HVACMode.OFF, *MODE_MAP_AUX_TO_HA.values()]
+        self._attr_hvac_modes = [HVACMode.OFF, *MODE_MAP_AUX_AC_TO_HA.values()]
         self._attr_fan_modes = list(FAN_MODE_HA_TO_AUX.keys())
         self._attr_swing_modes = [
             SWING_OFF,
@@ -277,7 +278,7 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         mode = self._get_device_params().get(AUX_MODE, None)
         if mode is None or not self._get_device_params().get(AC_POWER, False):
             return HVACMode.OFF
-        return MODE_MAP_AUX_TO_HA.get(mode, HVACMode.OFF)
+        return MODE_MAP_AUX_AC_TO_HA.get(mode, HVACMode.OFF)
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new operation mode."""
@@ -319,9 +320,7 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         if fan_mode is None:
             return
 
-        await self._set_device_params(
-            {ACFanSpeed.PARAM_NAME: FAN_MODE_HA_TO_AUX[fan_mode]}
-        )
+        await self._set_device_params({AC_FAN_SPEED: FAN_MODE_HA_TO_AUX[fan_mode]})
 
     @property
     def swing_mode(self):

--- a/custom_components/aux_cloud/climate.py
+++ b/custom_components/aux_cloud/climate.py
@@ -22,7 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import (
+from .api.const import (
     AC_FAN_SPEED,
     AUX_MODE,
     AC_SWING_HORIZONTAL,
@@ -47,7 +47,7 @@ from custom_components.aux_cloud.api.const import (
     AC_POWER_ON,
     ACFanSpeed,
 )
-from custom_components.aux_cloud.util import BaseEntity
+from .util import BaseEntity
 
 from .const import (
     DOMAIN,

--- a/custom_components/aux_cloud/const.py
+++ b/custom_components/aux_cloud/const.py
@@ -15,9 +15,6 @@ from custom_components.aux_cloud.api.const import (
     AC_MODE_FAN,
     AC_MODE_HEATING,
     AUX_MODE,
-    HP_MODE_AUTO,
-    HP_MODE_COOLING,
-    HP_MODE_HEATING,
     ACFanSpeed,
 )
 

--- a/custom_components/aux_cloud/const.py
+++ b/custom_components/aux_cloud/const.py
@@ -9,12 +9,15 @@ from homeassistant.components.climate import (
 )
 
 from custom_components.aux_cloud.api.const import (
+    AC_MODE_AUTO,
+    AC_MODE_COOLING,
+    AC_MODE_DRY,
+    AC_MODE_FAN,
+    AC_MODE_HEATING,
     AUX_MODE,
-    AUX_MODE_AUTO,
-    AUX_MODE_COOLING,
-    AUX_MODE_DRY,
-    AUX_MODE_FAN,
-    AUX_MODE_HEATING,
+    HP_MODE_AUTO,
+    HP_MODE_COOLING,
+    HP_MODE_HEATING,
     ACFanSpeed,
 )
 
@@ -28,17 +31,17 @@ DATA_AUX_CLOUD_CONFIG = "aux_cloud_config"
 CONF_FAMILIES = "families"
 CONF_SELECTED_DEVICES = "selected_devices"
 
-# Map AUX modes to Home Assistant HVAC modes
-MODE_MAP_AUX_TO_HA = {
-    AUX_MODE_AUTO.get(AUX_MODE): HVACMode.AUTO,
-    AUX_MODE_COOLING.get(AUX_MODE): HVACMode.COOL,
-    AUX_MODE_HEATING.get(AUX_MODE): HVACMode.HEAT,
-    AUX_MODE_DRY.get(AUX_MODE): HVACMode.DRY,
-    AUX_MODE_FAN.get(AUX_MODE): HVACMode.FAN_ONLY,
+# Map AUX AC modes to Home Assistant HVAC modes
+MODE_MAP_AUX_AC_TO_HA = {
+    AC_MODE_AUTO.get(AUX_MODE): HVACMode.AUTO,
+    AC_MODE_COOLING.get(AUX_MODE): HVACMode.COOL,
+    AC_MODE_HEATING.get(AUX_MODE): HVACMode.HEAT,
+    AC_MODE_DRY.get(AUX_MODE): HVACMode.DRY,
+    AC_MODE_FAN.get(AUX_MODE): HVACMode.FAN_ONLY,
 }
 
 # Reverse map for setting HVAC modes
-MODE_MAP_HA_TO_AUX = {v: k for k, v in MODE_MAP_AUX_TO_HA.items()}
+MODE_MAP_HA_TO_AUX = {v: k for k, v in MODE_MAP_AUX_AC_TO_HA.items()}
 
 # Fan mode constants
 FAN_MODE_HA_TO_AUX = {

--- a/custom_components/aux_cloud/const.py
+++ b/custom_components/aux_cloud/const.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate import (
     FAN_AUTO,
 )
 
-from custom_components.aux_cloud.api.const import (
+from .api.const import (
     AC_MODE_AUTO,
     AC_MODE_COOLING,
     AC_MODE_DRY,

--- a/custom_components/aux_cloud/manifest.json
+++ b/custom_components/aux_cloud/manifest.json
@@ -8,8 +8,7 @@
   "issue_tracker": "https://github.com/maeek/ha-aux-cloud/issues",
   "loggers": [],
   "requirements": [
-    "aiohttp==3.11.16",
-    "asyncio==3.4.3",
+    "aiohttp",
     "pycryptodome==3.21.0"
   ],
   "version": "0.1.0",

--- a/custom_components/aux_cloud/select.py
+++ b/custom_components/aux_cloud/select.py
@@ -6,7 +6,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import HP_QUIET_MODE
+from custom_components.aux_cloud.api.const import (
+    AUX_MODEL_PARAMS_LIST,
+    AUX_MODEL_SPECIAL_PARAMS_LIST,
+    HP_QUIET_MODE,
+)
+
 from .const import DOMAIN, _LOGGER
 from .util import BaseEntity
 
@@ -50,7 +55,18 @@ async def async_setup_entry(
     # Create select entities for each device
     for device in coordinator.data["devices"]:
         for entity in SELECTS.values():
-            if "params" in device and entity["description"].key in device["params"]:
+            if "productId" in device and (
+                (
+                    device["productId"] in AUX_MODEL_PARAMS_LIST
+                    and entity["description"].key
+                    in AUX_MODEL_PARAMS_LIST.get(device["productId"])
+                )
+                or (
+                    device["productId"] in AUX_MODEL_SPECIAL_PARAMS_LIST
+                    and entity["description"].key
+                    in AUX_MODEL_SPECIAL_PARAMS_LIST.get(device["productId"])
+                )
+            ):
                 entities.append(
                     AuxSelectEntity(
                         coordinator,

--- a/custom_components/aux_cloud/select.py
+++ b/custom_components/aux_cloud/select.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import (
+from .api.const import (
     AUX_MODEL_PARAMS_LIST,
     AUX_MODEL_SPECIAL_PARAMS_LIST,
     HP_QUIET_MODE,

--- a/custom_components/aux_cloud/sensor.py
+++ b/custom_components/aux_cloud/sensor.py
@@ -13,6 +13,8 @@ from custom_components.aux_cloud.api.const import (
     AC_TEMPERATURE_AMBIENT,
     AC_TEMPERATURE_TARGET,
     AUX_ERROR_FLAG,
+    AUX_MODEL_PARAMS_LIST,
+    AUX_MODEL_SPECIAL_PARAMS_LIST,
     HP_HOT_WATER_TANK_TEMPERATURE,
     HP_HOT_WATER_TEMPERATURE_TARGET,
     HP_HEATER_TEMPERATURE_TARGET,
@@ -117,9 +119,17 @@ async def async_setup_entry(
     _LOGGER.debug("Setting up AUX Cloud sensors %s", coordinator.data["devices"])
     for device in coordinator.data["devices"]:
         for entity in SENSORS.values():
-            if (
-                "params" in device
-                and device.get("params", {}).get(entity["param"]) is not None
+            if "productId" in device and (
+                (
+                    device["productId"] in AUX_MODEL_PARAMS_LIST
+                    and entity["param"]
+                    in AUX_MODEL_PARAMS_LIST.get(device["productId"])
+                )
+                or (
+                    device["productId"] in AUX_MODEL_SPECIAL_PARAMS_LIST
+                    and entity["param"]
+                    in AUX_MODEL_SPECIAL_PARAMS_LIST.get(device["productId"])
+                )
             ):
                 sensor = AuxCloudSensor(
                     coordinator,

--- a/custom_components/aux_cloud/sensor.py
+++ b/custom_components/aux_cloud/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import (
+from .api.const import (
     AC_TEMPERATURE_AMBIENT,
     AC_TEMPERATURE_TARGET,
     AUX_ERROR_FLAG,
@@ -19,7 +19,7 @@ from custom_components.aux_cloud.api.const import (
     HP_HOT_WATER_TEMPERATURE_TARGET,
     HP_HEATER_TEMPERATURE_TARGET,
 )
-from custom_components.aux_cloud.util import BaseEntity
+from .util import BaseEntity
 from .const import DOMAIN, _LOGGER
 
 SENSORS: dict[str, dict[str, any]] = {

--- a/custom_components/aux_cloud/switch.py
+++ b/custom_components/aux_cloud/switch.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import (
+from .api.const import (
     AC_AUXILIARY_HEAT,
     AC_CHILD_LOCK,
     AC_CLEAN,
@@ -24,7 +24,7 @@ from custom_components.aux_cloud.api.const import (
     HP_WATER_FAST_HOTWATER,
     HP_WATER_POWER,
 )
-from custom_components.aux_cloud.util import BaseEntity
+from .util import BaseEntity
 from .const import DOMAIN, _LOGGER
 
 SWITCHES = {

--- a/custom_components/aux_cloud/switch.py
+++ b/custom_components/aux_cloud/switch.py
@@ -15,6 +15,8 @@ from custom_components.aux_cloud.api.const import (
     AC_SCREEN_DISPLAY,
     AC_SLEEP,
     AUX_ECOMODE,
+    AUX_MODEL_PARAMS_LIST,
+    AUX_MODEL_SPECIAL_PARAMS_LIST,
     HP_HEATER_AUTO_WATER_TEMP,
     HP_HEATER_AUTO_WATER_TEMP_OFF,
     HP_HEATER_AUTO_WATER_TEMP_ON,
@@ -157,26 +159,37 @@ async def async_setup_entry(
     entities = []
 
     for device in coordinator.data["devices"]:
-        if "params" in device:
-            for switch in SWITCHES.values():
-                if switch["description"].key in device["params"]:
-                    entities.append(
-                        AuxSwitchEntity(
-                            coordinator,
-                            device["endpointId"],
-                            switch["description"],
-                            (
-                                switch["custom_mapping"]
-                                if "custom_mapping" in switch
-                                else None
-                            ),
-                        )
+        for switch in SWITCHES.values():
+            if "productId" in device and (
+                (
+                    device["productId"] in AUX_MODEL_PARAMS_LIST
+                    and switch["description"].key
+                    in AUX_MODEL_PARAMS_LIST.get(device["productId"])
+                )
+                or (
+                    device["productId"] in AUX_MODEL_SPECIAL_PARAMS_LIST
+                    and switch["description"].key
+                    in AUX_MODEL_SPECIAL_PARAMS_LIST.get(device["productId"])
+                )
+            ):
+                entities.append(
+                    AuxSwitchEntity(
+                        coordinator,
+                        device["endpointId"],
+                        switch["description"],
+                        (
+                            switch["custom_mapping"]
+                            if "custom_mapping" in switch
+                            else None
+                        ),
                     )
-                    _LOGGER.debug(
-                        "Adding switch entity for %s with option %s",
-                        device["friendlyName"],
-                        switch["description"].key,
-                    )
+                )
+                _LOGGER.debug(
+                    "Adding switch entity for %s with option %s",
+                    device["friendlyName"],
+                    switch["description"].key,
+                )
+
     if entities:
         async_add_entities(entities, True)
     else:

--- a/custom_components/aux_cloud/util.py
+++ b/custom_components/aux_cloud/util.py
@@ -2,8 +2,8 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import AUX_MODEL_TO_NAME
-from custom_components.aux_cloud.const import _LOGGER, DOMAIN, MANUFACTURER
+from .api.const import AUX_MODEL_TO_NAME
+from .const import _LOGGER, DOMAIN, MANUFACTURER
 
 
 class BaseEntity(CoordinatorEntity):

--- a/custom_components/aux_cloud/water_heater.py
+++ b/custom_components/aux_cloud/water_heater.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.aux_cloud.api.const import (
+from .api.const import (
     AuxProductCategory,
     AUX_ECOMODE,
     HP_HOT_WATER_TANK_TEMPERATURE,
@@ -25,7 +25,7 @@ from custom_components.aux_cloud.api.const import (
     HP_WATER_POWER_ON,
     HP_QUIET_MODE,
 )
-from custom_components.aux_cloud.util import BaseEntity
+from .util import BaseEntity
 from .const import DOMAIN, _LOGGER
 
 WATER_HEATER_ENTITIES: dict[str, dict[str, any]] = {


### PR DESCRIPTION
- Fixes issue when initializing integration with some of devices being offline. When that happend only climate and water heater entities were initialized. Now all available entities will be initialized and will be unavailable until they become online again.
- Decreased polling interval to 1 minute - for 5 devices the total fetching time is 2s
- Fixed various pylint issues, new score is 9.24