### PR TITLE
Fix unit_of_measurement of climate entity

### DIFF
--- a/custom_components/aux_cloud/climate.py
+++ b/custom_components/aux_cloud/climate.py
@@ -82,7 +82,6 @@ async def async_setup_entry(
                         name="Air Conditioner",
                         translation_key="aux_ac",
                         icon="mdi:air-conditioner",
-                        unit_of_measurement=UnitOfTemperature.CELSIUS,
                     ),
                 )
             )
@@ -96,7 +95,6 @@ async def async_setup_entry(
                         name="Central Heating",
                         translation_key="aux_heater",
                         icon="mdi:hvac",
-                        unit_of_measurement=UnitOfTemperature.CELSIUS,
                     ),
                 )
             )
@@ -125,7 +123,7 @@ class AuxHeatPumpClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         self._attr_min_temp = 0  # Minimum temperature in Celsius
         self._attr_max_temp = 64  # Maximum temperature in Celsius
         self._attr_target_temperature_step = 1
-        self._attr_temperature_unit = entity_description.unit_of_measurement
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_preset_modes = [PRESET_NONE, PRESET_ECO]
         self.entity_id = f"climate.{self._attr_unique_id}"
 
@@ -220,7 +218,7 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
     ):
         """Initialize the climate entity."""
         super().__init__(coordinator, device_id, entity_description)
-        self._attr_temperature_unit = entity_description.unit_of_measurement
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE


### PR DESCRIPTION
Hi,

First of all, many many thanks for this integration, finally I have my AC in Home Assistant!

I noticed that something was a bit off with the list of HVAC modes in the UI, it showed the raw value together with degrees Celsius. This was due to the unit_of_measurement (UOM) being in the state_attributes, which was caused by the UOM attribute in the ClimateEntityDescription. This UOM gets somehow copied into the state_attributes and therefore the UI thinks that the climate entity's state has a UOM while it hasn't, it only has a temperature_unit which is different.

Since the UOM is always Celsius, I just copied the value into the _attr_temperature_unit attribute.

This will make sure that the dropdown list of possible hvac_modes shows the proper and translated values in the frontend. An example (sorry it is in Dutch) 
<img width="302" alt="image" src="https://github.com/user-attachments/assets/e06e8954-e43b-430b-80dc-73858968476d" />


Again, many thanks!

Bye :)