### PR TITLE
feat: implement optimistic updates and state failsafe

### DIFF
--- a/custom_components/aux_cloud/__init__.py
+++ b/custom_components/aux_cloud/__init__.py
@@ -18,7 +18,9 @@ from .const import (
     DATA_AUX_CLOUD_CONFIG,
     PLATFORMS,
     CONF_SELECTED_DEVICES,
+    MAX_FAILED_POLLS,
 )
+from .util import DeviceStateHelper
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
@@ -91,6 +93,7 @@ class AuxCloudCoordinator(DataUpdateCoordinator):
         self.password = password
         self.selected_device_ids = selected_device_ids
         self.devices = []
+        self._device_state_helpers: dict[str, DeviceStateHelper] = {}
 
     def get_device_by_endpoint_id(self, endpoint_id: str):
         """Get a device by its endpoint ID."""
@@ -102,6 +105,14 @@ class AuxCloudCoordinator(DataUpdateCoordinator):
             ),
             None,
         )
+
+    def get_state_helper(self, endpoint_id: str, initial_params: dict) -> DeviceStateHelper:
+        """Get or create a shared state helper for a single physical device."""
+        helper = self._device_state_helpers.get(endpoint_id)
+        if helper is None:
+            helper = DeviceStateHelper(initial_params, MAX_FAILED_POLLS)
+            self._device_state_helpers[endpoint_id] = helper
+        return helper
 
     async def _async_update_data(self):
         """Fetch data from AUX Cloud."""
@@ -158,6 +169,15 @@ class AuxCloudCoordinator(DataUpdateCoordinator):
 
             self.devices = all_devices
             _LOGGER.debug("Fetched AUX Cloud data: %s devices", len(self.devices))
+
+            current_endpoint_ids = {
+                device["endpointId"]
+                for device in self.devices
+                if "endpointId" in device
+            }
+            stale_helpers = set(self._device_state_helpers) - current_endpoint_ids
+            for endpoint_id in stale_helpers:
+                self._device_state_helpers.pop(endpoint_id, None)
 
             self.async_set_updated_data({"devices": self.devices})
 

--- a/custom_components/aux_cloud/const.py
+++ b/custom_components/aux_cloud/const.py
@@ -63,3 +63,5 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.NUMBER,
 ]
+
+MAX_FAILED_POLLS = 5

--- a/custom_components/aux_cloud/util.py
+++ b/custom_components/aux_cloud/util.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api.const import AuxProducts
-from .const import _LOGGER, DOMAIN, MANUFACTURER, MAX_FAILED_POLLS
+from .const import _LOGGER, DOMAIN, MANUFACTURER
 
 
 class DeviceStateHelper:
@@ -17,6 +17,7 @@ class DeviceStateHelper:
         self._max_failed_polls = max_failed_polls
         self._backup_params: dict[str, Any] = {}
         self._last_logged_payload: str | None = None
+        self._last_processed_update_id: int | None = None
 
     @property
     def current_params(self) -> dict[str, Any]:
@@ -27,8 +28,19 @@ class DeviceStateHelper:
         """Determines if the entity should be marked as available."""
         return bool(len(self._cached_params) > 0 and self._failed_poll_count <= self._max_failed_polls)
 
-    def process_new_payload(self, current_params: dict[str, Any], device_name: str):
+    def process_new_payload(
+        self,
+        current_params: dict[str, Any],
+        device_name: str,
+        update_id: int | None = None,
+    ):
         """Orchestrates the processing of incoming payloads."""
+        if update_id is not None and update_id == self._last_processed_update_id:
+            return
+
+        if update_id is not None:
+            self._last_processed_update_id = update_id
+
         self._log_payload_if_changed(current_params, device_name)
 
         if not current_params:
@@ -110,7 +122,10 @@ class BaseEntity(CoordinatorEntity):
         )
 
         initial_params = self._device.get("params", {}) if self._device else {}
-        self._state_helper = DeviceStateHelper(initial_params, MAX_FAILED_POLLS)
+        self._state_helper = self.coordinator.get_state_helper(
+            self._device_id,
+            initial_params,
+        )
 
     @property
     def unique_id(self) -> str | None:
@@ -151,7 +166,11 @@ class BaseEntity(CoordinatorEntity):
         device_name = self._device.get("friendlyName", self._device_id)
 
         # Helper is now the source of truth for params
-        self._state_helper.process_new_payload(raw_params, device_name)
+        self._state_helper.process_new_payload(
+            raw_params,
+            device_name,
+            update_id=id(self.coordinator.data),
+        )
 
         self.async_write_ha_state()
 

--- a/custom_components/aux_cloud/util.py
+++ b/custom_components/aux_cloud/util.py
@@ -1,13 +1,104 @@
+from typing import Any
+
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api.const import AuxProducts
-from .const import _LOGGER, DOMAIN, MANUFACTURER
+from .const import _LOGGER, DOMAIN, MANUFACTURER, MAX_FAILED_POLLS
+
+
+class DeviceStateHelper:
+    """Helper class to manage device parameters state, failsafe, and optimistic updates."""
+
+    def __init__(self, initial_params: dict[str, Any], max_failed_polls: int):
+        self._cached_params: dict[str, Any] = initial_params.copy() if initial_params else {}
+        self._failed_poll_count = 0
+        self._max_failed_polls = max_failed_polls
+        self._backup_params: dict[str, Any] = {}
+        self._last_logged_payload: str | None = None
+
+    @property
+    def current_params(self) -> dict[str, Any]:
+        """Return the current verified parameters."""
+        return self._cached_params
+
+    def is_available(self) -> bool:
+        """Determines if the entity should be marked as available."""
+        return bool(len(self._cached_params) > 0 and self._failed_poll_count <= self._max_failed_polls)
+
+    def process_new_payload(self, current_params: dict[str, Any], device_name: str):
+        """Orchestrates the processing of incoming payloads."""
+        self._log_payload_if_changed(current_params, device_name)
+
+        if not current_params:
+            self._handle_empty_payload(device_name)
+            return
+
+        self._handle_valid_payload(current_params, device_name)
+
+    def _log_payload_if_changed(self, current_params: dict[str, Any], device_name: str):
+        """Logs the raw payload only if it differs from the last logged one."""
+        current_payload_str = str(current_params)
+        if current_payload_str != self._last_logged_payload:
+            _LOGGER.debug("State changed or new poll. Raw payload for %s: %s", device_name, current_params)
+            self._last_logged_payload = current_payload_str
+
+    def _handle_empty_payload(self, device_name: str):
+        """Handles network errors or empty responses, managing the failsafe counter."""
+        self._failed_poll_count += 1
+
+        if self._failed_poll_count <= self._max_failed_polls:
+            _LOGGER.warning(
+                "Empty payload for device %s (Attempt %s/%s). Using cache to prevent flapping.",
+                device_name, self._failed_poll_count, self._max_failed_polls
+            )
+            return
+
+        if self._failed_poll_count == self._max_failed_polls + 1:
+            _LOGGER.error(
+                "Device %s dropped connection for %s polls. Marking as unavailable.",
+                device_name, self._failed_poll_count
+            )
+            self._cached_params = {}
+
+    def _handle_valid_payload(self, current_params: dict[str, Any], device_name: str):
+        """Merges a valid partial or full payload into the cache and resets counters."""
+        if self._failed_poll_count > 0:
+            _LOGGER.info(
+                "Device %s connection restored after %s failed attempts.",
+                device_name, self._failed_poll_count
+            )
+
+        self._failed_poll_count = 0
+        self._cached_params.update(current_params)
+
+    def apply_optimistic(self, new_params: dict[str, Any]):
+        """Applies new params optimistically and saves a backup for rollback."""
+        self._backup_params.clear()
+
+        for key, value in new_params.items():
+            if key in self._cached_params:
+                self._backup_params[key] = self._cached_params[key]
+            self._cached_params[key] = value
+
+        self._last_logged_payload = None
+
+    def rollback(self, failed_params: dict[str, Any]):
+        """Rolls back the optimistic update if API call fails."""
+        for key in failed_params:
+            if key in self._backup_params:
+                self._cached_params[key] = self._backup_params[key]
+            else:
+                self._cached_params.pop(key, None)
+        self._backup_params.clear()
+        self._last_logged_payload = None
 
 
 class BaseEntity(CoordinatorEntity):
-    def __init__(self, coordinator, device_id, entity_description):
+    """Base class for all AUX Cloud entities."""
+
+    def __init__(self, coordinator: Any, device_id: str, entity_description: Any):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._device_id = device_id
@@ -18,50 +109,71 @@ class BaseEntity(CoordinatorEntity):
             f"{DOMAIN}_{self._device_id.lstrip('0')}_{self.entity_description.key}"
         )
 
+        initial_params = self._device.get("params", {}) if self._device else {}
+        self._state_helper = DeviceStateHelper(initial_params, MAX_FAILED_POLLS)
+
     @property
-    def unique_id(self):
-        """Return a unique ID for the sensor."""
+    def unique_id(self) -> str | None:
+        """Return a unique ID for the entity."""
         return self._attr_unique_id
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return the device info."""
-        return DeviceInfo(
-            connections=(
-                {(CONNECTION_NETWORK_MAC, self._device["mac"])}
-                if "mac" in self._device
-                else None
-            ),
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device.get("friendlyName", "AUX"),
+        info = DeviceInfo(
+            identifiers={(DOMAIN, str(self._device_id))},
+            name=str(self._device.get("friendlyName", "AUX")),
             manufacturer=MANUFACTURER,
-            model=AuxProducts.get_device_name(self._device.get("productId", None)),
+            model=str(AuxProducts.get_device_name(self._device.get("productId", None))),
         )
 
+        if "mac" in self._device and self._device["mac"]:
+            info["connections"] = {(CONNECTION_NETWORK_MAC, str(self._device["mac"]))}
+
+        return info
+
     @property
-    def available(self):
+    def available(self) -> bool:
         """Return True if entity is available."""
         return (
-            self._device is not None
-            and self._device.get("endpointId") is not None
-            and len(self._device.get("params", {}).keys()) > 0
+                self._device is not None
+                and self._device.get("endpointId") is not None
+                and self._state_helper.is_available()
         )
 
     @callback
     def _handle_coordinator_update(self):
-        device_from_coordinator = self.coordinator.get_device_by_endpoint_id(
-            self._device_id
-        )
+        """Handle updated data from the coordinator."""
+        device_from_coordinator = self.coordinator.get_device_by_endpoint_id(self._device_id)
         self._device = device_from_coordinator or {}
+
+        raw_params = self._device.get("params", {})
+        device_name = self._device.get("friendlyName", self._device_id)
+
+        # Helper is now the source of truth for params
+        self._state_helper.process_new_payload(raw_params, device_name)
 
         self.async_write_ha_state()
 
-    def _get_device_params(self):
-        return self._device.get("params", {})
+    def _get_device_params(self) -> dict[str, Any]:
+        """Get device parameters securely from the state helper."""
+        return self._state_helper.current_params
 
-    async def _set_device_params(self, params: dict):
-        """Set parameters on the device."""
-        _LOGGER.debug("Setting %s for device %s", params, self._device["friendlyName"])
+    async def _set_device_params(self, params: dict[str, Any]):
+        """Set parameters on the device using Optimistic Updates via Helper."""
+        device_name = self._device.get("friendlyName", self._device_id)
+        _LOGGER.debug("Optimistically setting %s for device %s", params, device_name)
 
-        await self.coordinator.api.set_device_params(self._device, params)
-        await self.coordinator.async_request_refresh()
+        # Apply changes to the internal state immediately
+        self._state_helper.apply_optimistic(params)
+        self.async_write_ha_state()
+
+        try:
+            await self.coordinator.api.set_device_params(self._device, params)
+            # Refresh coordinator to sync all dependent entities immediately after a successful write
+            await self.coordinator.async_request_refresh()
+        except Exception as err:
+            _LOGGER.error("Failed to apply setting %s to %s: %s", params, device_name, err)
+            self._state_helper.rollback(params)
+            self.async_write_ha_state()
+            raise

--- a/tests/test_aux_cloud_coordinator.py
+++ b/tests/test_aux_cloud_coordinator.py
@@ -152,3 +152,28 @@ async def test_coordinator_handle_exception_results(coordinator, mock_aux_cloud_
     assert "devices" in data
     assert len(data["devices"]) == 1
     assert data["devices"][0]["endpointId"] == "device1"
+
+
+def test_coordinator_reuses_state_helper_per_device(coordinator):
+    """Test coordinator returns the same helper instance per endpoint ID."""
+    helper_a = coordinator.get_state_helper("device1", {"pwr": 1})
+    helper_b = coordinator.get_state_helper("device1", {"pwr": 0, "temp": 230})
+
+    assert helper_a is helper_b
+    assert helper_a.current_params == {"pwr": 1}
+
+
+def test_state_helper_deduplicates_same_update_id(coordinator):
+    """Test helper processes a single coordinator update only once."""
+    helper = coordinator.get_state_helper("device1", {"pwr": 1})
+
+    helper.process_new_payload({}, "AC Unit 1", update_id=1)
+    helper.process_new_payload({}, "AC Unit 1", update_id=1)
+    helper.process_new_payload({}, "AC Unit 1", update_id=1)
+
+    assert helper.is_available() is True
+
+    for update_id in range(2, 7):
+        helper.process_new_payload({}, "AC Unit 1", update_id=update_id)
+
+    assert helper.is_available() is False


### PR DESCRIPTION
Hi! First of all, thank you so much for this integration. I've been using it daily for quite some time now, and it's been an essential part of my setup.

While monitoring its behavior, I noticed a few areas where the robustness and user experience could be improved. Specifically regarding how temporary API hiccups or partial payloads affect entity availability, and the responsiveness of the UI when sending commands.

- DeviceStateHelper: Acts as the single source of truth for device parameters. It safely merges incoming payloads, ensuring partial updates from the API do not overwrite the current valid state.
- MAX_FAILED_POLLS Failsafe: Prevents entity flapping by allowing up to 5 consecutive failed polling attempts before marking the device as unavailable, falling back to the cached state during temporary drops.
- Optimistic State Updates: Commands (e.g., changing temperature or modes) update the UI instantly instead of waiting for the next coordinator poll cycle.
- Automatic Rollback Mechanism: If an API call fails, the helper rolls back parameters to their cached values and raises the error so Home Assistant is properly notified.
- Refactored BaseEntity: Updated the base class to use DeviceStateHelper for parameter management.
- Improved Static Typing: Added Python type hints across util.py to align with Home Assistant standards.