### PR TITLE
fix: add icons for turbo and silent fan modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ pipfile
 pipfile.lock
 .idea
 /config.yaml
+
+# Local Home Assistant dev/debug instance
+/venv
+/config

--- a/custom_components/aux_cloud/icons.json
+++ b/custom_components/aux_cloud/icons.json
@@ -1,0 +1,16 @@
+{
+  "entity": {
+    "climate": {
+      "aux_ac": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "turbo": "mdi:weather-tornado",
+              "silent": "mdi:volume-off"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix for lack of icons in turbo and silent fan mode. 
Previuse
<img width="785" height="624" alt="obraz" src="https://github.com/user-attachments/assets/eb939f81-20d3-4e29-aa37-3b1a69b0c053" />
New
<img width="785" height="624" alt="obraz" src="https://github.com/user-attachments/assets/ed8c9c62-a5dc-4d8a-8c95-deb015a8849a" />
