### PR TITLE
Fix: heat pump entities going unavailable and coordinator crash on network errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,6 @@ pipfile.lock
 .venv/
 *.log
 .DS_Store
-custom_components/aux_cloud/config/home-assistant_v2.db
-custom_components/aux_cloud/config/.storage/
-custom_components/aux_cloud/config/.cache/
-custom_components/aux_cloud/config/tts/
-custom_components/aux_cloud/config/blueprints/
-custom_components/aux_cloud/config/.cloud/
-custom_components/aux_cloud/config/.ha_run.lock
+
+# Local Home Assistant dev instance (contains DB, auth tokens, logs)
+custom_components/aux_cloud/config/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@ pipfile
 pipfile.lock
 .idea
 /config.yaml
+.venv/
+*.log
+.DS_Store
+custom_components/aux_cloud/config/home-assistant_v2.db
+custom_components/aux_cloud/config/.storage/
+custom_components/aux_cloud/config/.cache/
+custom_components/aux_cloud/config/tts/
+custom_components/aux_cloud/config/blueprints/
+custom_components/aux_cloud/config/.cloud/
+custom_components/aux_cloud/config/.ha_run.lock

--- a/custom_components/aux_cloud/__init__.py
+++ b/custom_components/aux_cloud/__init__.py
@@ -158,6 +158,9 @@ class AuxCloudCoordinator(DataUpdateCoordinator):
             all_devices = []
 
             for result in devices_results:
+                if isinstance(result, BaseException):
+                    _LOGGER.error("Error fetching devices for a family: %s", result)
+                    continue
                 for device in result:
                     if isinstance(device, Exception):
                         continue

--- a/custom_components/aux_cloud/api/aux_cloud.py
+++ b/custom_components/aux_cloud/api/aux_cloud.py
@@ -389,16 +389,22 @@ class AuxCloudAPI:
 
                 if dev_params is None or isinstance(dev_params, BaseException):
                     _LOGGER.error(
-                        "Error fetching device params for %s",
+                        "Error fetching device params for %s: %s",
                         dev["endpointId"],
+                        dev_params,
                     )
-                    continue
+                else:
+                    dev["params"] = dev_params or {}
 
-                dev["params"] = dev_params or {}
-
-                if dev_special_params and not isinstance(
+                if dev_special_params is not None and isinstance(
                     dev_special_params, BaseException
                 ):
+                    _LOGGER.error(
+                        "Error fetching special device params for %s: %s",
+                        dev["endpointId"],
+                        dev_special_params,
+                    )
+                elif dev_special_params:
                     dev["params"].update(dev_special_params)
 
                 # Heat pump tank temperature decoding


### PR DESCRIPTION
Problem                                                                                                                                                             

1. Entities going unavailable – FUNCTION_NOT_SUPPORT errors from default param queries caused the loop to abort before merging special_params, leaving dev["params"] empty.                                                                                                                                                                     
2. Coordinator crash – network exceptions during get_devices were iterated as results in asyncio.gather, causing 'X' object is not iterable.                                                                                                                                                                                                         

Solution                                                                                                                                                                   

1. api/aux_cloud.py – errors in the first query no longer skip the second; special_params are still fetched and merged.                                                     
2. __init__.py – added isinstance(result, BaseException) check to skip exception results in the coordinator