### PR TITLE
Fix optimistic temperature setpoints reverting shortly after being set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pipfile
 pipfile.lock
 .idea
 /config.yaml
+docs/dev/config.yaml
 .venv/
 *.log
 .DS_Store

--- a/custom_components/aux_cloud/api/aux_cloud.py
+++ b/custom_components/aux_cloud/api/aux_cloud.py
@@ -74,6 +74,30 @@ class AuxApiError(Exception):
     """Exception raised when querying devices fails."""
 
 
+# The physical device's WiFi module occasionally drops off AUX's cloud
+# servers for a moment, which surfaces as a NETWORK_TIME_OUT/unreachable
+# ErrorResponse rather than an HTTP-level failure. These are almost always
+# transient, so a couple of quick retries avoids surfacing a hard failure
+# (and an optimistic-update rollback) to the user for a blip that would have
+# resolved itself a second later.
+RETRYABLE_ERROR_TYPES = {"NETWORK_TIME_OUT", "ENDPOINT_UNREACHABLE"}
+MAX_ACT_DEVICE_RETRIES = 2
+ACT_DEVICE_RETRY_DELAY_SECONDS = 2
+
+
+def _get_error_response_type(json_data: dict) -> str | None:
+    """Return the error type of an AUX ErrorResponse payload, if any."""
+    event = json_data.get("event") if isinstance(json_data, dict) else None
+    if not isinstance(event, dict):
+        return None
+
+    header = event.get("header", {})
+    if header.get("name") != "ErrorResponse":
+        return None
+
+    return event.get("payload", {}).get("type")
+
+
 def _decode_v3_hp_tank_temp_from_key_states(key_states_hex: str) -> int | None:
     """Decode heat pump tank temperature from key_states.
 
@@ -597,38 +621,58 @@ class AuxCloudAPI:
         # Keep original integration behavior for single-param GET
         if len(req_params) == 1 and act == "get":
             data["directive"]["payload"]["vals"] = [[{"val": 0, "idx": 1}]]
-        json_data = await self._make_request(
-            method="POST",
-            endpoint="device/control/v2/sdkcontrol",
-            data=data,
-            # Theoretically license in query param is not needed but
-            # I'm following the original request made from the app,
-            # just in case.
-            params={"license": LICENSE},
-            headers=self._get_headers(),
-            ssl=False,
-        )
 
-        _LOGGER.debug("Device params response: %s", json_data)
+        last_json_data = None
 
-        if (
-            "event" in json_data
-            and "payload" in json_data["event"]
-            and "data" in json_data["event"]["payload"]
-            and "header" in json_data["event"]
-            and "name" in json_data["event"]["header"]
-            # Ensure it's not an error response
-            and json_data["event"]["header"]["name"] == "Response"
-        ):
-            response = json.loads(json_data["event"]["payload"]["data"])
-            response_dict = {}
+        for attempt in range(1, MAX_ACT_DEVICE_RETRIES + 2):
+            json_data = await self._make_request(
+                method="POST",
+                endpoint="device/control/v2/sdkcontrol",
+                data=data,
+                # Theoretically license in query param is not needed but
+                # I'm following the original request made from the app,
+                # just in case.
+                params={"license": LICENSE},
+                headers=self._get_headers(),
+                ssl=False,
+            )
 
-            for i in range(0, len(response["params"])):
-                response_dict[response["params"][i]] = response["vals"][i][0]["val"]
+            _LOGGER.debug("Device params response: %s", json_data)
 
-            return response_dict
+            if (
+                "event" in json_data
+                and "payload" in json_data["event"]
+                and "data" in json_data["event"]["payload"]
+                and "header" in json_data["event"]
+                and "name" in json_data["event"]["header"]
+                # Ensure it's not an error response
+                and json_data["event"]["header"]["name"] == "Response"
+            ):
+                response = json.loads(json_data["event"]["payload"]["data"])
+                response_dict = {}
 
-        raise AuxApiError(f"Failed to query device state: {data}, {json_data}")
+                for i in range(0, len(response["params"])):
+                    response_dict[response["params"][i]] = response["vals"][i][0]["val"]
+
+                return response_dict
+
+            last_json_data = json_data
+            error_type = _get_error_response_type(json_data)
+
+            if error_type not in RETRYABLE_ERROR_TYPES or attempt > MAX_ACT_DEVICE_RETRIES:
+                break
+
+            _LOGGER.warning(
+                "Device %s returned retryable error %s (attempt %s/%s), retrying in %ss...",
+                device["endpointId"],
+                error_type,
+                attempt,
+                MAX_ACT_DEVICE_RETRIES + 1,
+                ACT_DEVICE_RETRY_DELAY_SECONDS,
+            )
+            await asyncio.sleep(ACT_DEVICE_RETRY_DELAY_SECONDS)
+
+        raise AuxApiError(f"Failed to query device state: {data}, {last_json_data}")
 
     async def get_device_params(self, device: dict, params: list[str] = None):
         """

--- a/custom_components/aux_cloud/api/const.py
+++ b/custom_components/aux_cloud/api/const.py
@@ -17,6 +17,8 @@ AC_POWER_ON = {AC_POWER: 1}
 
 AC_TEMPERATURE_TARGET = "temp"
 AC_TEMPERATURE_AMBIENT = "envtemp"
+AC_TEMPERATURE_CONVERT = "ac_tempconvert"
+AC_TEMPERATURE_UNIT = "tempunit"
 
 AC_MODE_COOLING = {AUX_MODE: 0}
 AC_MODE_HEATING = {AUX_MODE: 1}
@@ -161,10 +163,10 @@ class AuxProducts:
         AC_CHILD_LOCK,
         AC_COMFORTABLE_WIND,
         "new_type",
-        "ac_tempconvert",
+        AC_TEMPERATURE_CONVERT,
         "sleepdiy",
         "ac_errcode1",
-        "tempunit",
+        AC_TEMPERATURE_UNIT,
         "tenelec",  # Unknown, might be available when the device is in specific state
     ]
 

--- a/custom_components/aux_cloud/climate.py
+++ b/custom_components/aux_cloud/climate.py
@@ -53,6 +53,7 @@ from .const import (
     FAN_MODE_AUX_TO_HA,
     MODE_MAP_AUX_AC_TO_HA,
     MODE_MAP_HA_TO_AUX,
+    SET_TEMPERATURE_DEBOUNCE_SECONDS,
     _LOGGER,
 )
 from .util import BaseEntity
@@ -206,7 +207,8 @@ class AuxHeatPumpClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
             temperature = self._attr_max_temp
 
         await self._set_device_params(
-            {HP_HEATER_TEMPERATURE_TARGET: int(temperature * 10)}
+            {HP_HEATER_TEMPERATURE_TARGET: round(temperature * 10)},
+            debounce_seconds=SET_TEMPERATURE_DEBOUNCE_SECONDS,
         )
 
     async def async_set_fan_mode(self, fan_mode):
@@ -241,7 +243,13 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         ]
         self._attr_min_temp = 16
         self._attr_max_temp = 32
-        self._attr_target_temperature_step = 0.5
+        # The device's own capability profile declares its "temp" parameter
+        # as a whole-Celsius-degree range (min=16, max=32, step=1). Sending a
+        # fractional Celsius value (e.g. from a Fahrenheit-to-Celsius
+        # conversion that doesn't land on a whole degree) is silently
+        # ignored by the hardware - it beeps to acknowledge receipt but never
+        # applies it. So the step must match that whole-degree granularity.
+        self._attr_target_temperature_step = 1
         self.entity_id = f"climate.{self._attr_unique_id}"
 
     @property
@@ -273,7 +281,16 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         elif temperature > self._attr_max_temp:
             temperature = self._attr_max_temp
 
-        await self._set_device_params({AC_TEMPERATURE_TARGET: int(temperature * 10)})
+        # Snap to a whole Celsius degree - the device only supports whole
+        # degree setpoints (see _attr_target_temperature_step above), so a
+        # fractional value (e.g. converted from Fahrenheit) would otherwise
+        # be silently ignored by the hardware.
+        temperature = round(temperature)
+
+        await self._set_device_params(
+            {AC_TEMPERATURE_TARGET: round(temperature * 10)},
+            debounce_seconds=SET_TEMPERATURE_DEBOUNCE_SECONDS,
+        )
 
     @property
     def hvac_mode(self):

--- a/custom_components/aux_cloud/climate.py
+++ b/custom_components/aux_cloud/climate.py
@@ -32,6 +32,7 @@ from .api.const import (
     AC_SWING_VERTICAL_OFF,
     AC_SWING_VERTICAL_ON,
     AC_TEMPERATURE_AMBIENT,
+    AC_TEMPERATURE_UNIT,
     AC_TEMPERATURE_TARGET,
     HP_MODE_COOLING,
     HP_MODE_HEATING,
@@ -57,6 +58,11 @@ from .const import (
     _LOGGER,
 )
 from .util import BaseEntity
+from .temperature import (
+    AUX_TEMPERATURE_UNIT_FAHRENHEIT,
+    decode_ac_target_temperature,
+    encode_ac_target_temperature,
+)
 
 
 async def async_setup_entry(
@@ -225,7 +231,10 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
     ):
         """Initialize the climate entity."""
         super().__init__(coordinator, device_id, entity_description)
-        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        if self._uses_fahrenheit_encoding:
+            self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+        else:
+            self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE
@@ -241,34 +250,39 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
             SWING_HORIZONTAL,
             SWING_BOTH,
         ]
-        self._attr_min_temp = 16
-        self._attr_max_temp = 32
-        # The device's own capability profile declares its "temp" parameter
-        # as a whole-Celsius-degree range (min=16, max=32, step=1). Sending a
-        # fractional Celsius value (e.g. from a Fahrenheit-to-Celsius
-        # conversion that doesn't land on a whole degree) is silently
-        # ignored by the hardware - it beeps to acknowledge receipt but never
-        # applies it. So the step must match that whole-degree granularity.
+        if self._uses_fahrenheit_encoding:
+            self._attr_min_temp = 60
+            self._attr_max_temp = 90
+        else:
+            self._attr_min_temp = 16
+            self._attr_max_temp = 32
         self._attr_target_temperature_step = 1
         self.entity_id = f"climate.{self._attr_unique_id}"
 
     @property
+    def _uses_fahrenheit_encoding(self) -> bool:
+        """Return whether this device uses AUX's split Fahrenheit encoding."""
+        return (
+            self._get_device_params().get(AC_TEMPERATURE_UNIT)
+            == AUX_TEMPERATURE_UNIT_FAHRENHEIT
+        )
+
+    @property
     def current_temperature(self):
         """Return the current temperature."""
-        return (
-            self._get_device_params().get(AC_TEMPERATURE_AMBIENT, None) / 10
-            if AC_TEMPERATURE_AMBIENT in self._get_device_params()
-            else None
-        )
+        raw_temp = self._get_device_params().get(AC_TEMPERATURE_AMBIENT)
+        if raw_temp is None:
+            return None
+
+        celsius = raw_temp / 10
+        if self._uses_fahrenheit_encoding:
+            return celsius * 9 / 5 + 32
+        return celsius
 
     @property
     def target_temperature(self):
         """Return the target temperature."""
-        return (
-            self._get_device_params().get(AC_TEMPERATURE_TARGET, None) / 10
-            if AC_TEMPERATURE_TARGET in self._get_device_params()
-            else None
-        )
+        return decode_ac_target_temperature(self._get_device_params())
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -281,14 +295,11 @@ class AuxACClimateEntity(BaseEntity, CoordinatorEntity, ClimateEntity):
         elif temperature > self._attr_max_temp:
             temperature = self._attr_max_temp
 
-        # Snap to a whole Celsius degree - the device only supports whole
-        # degree setpoints (see _attr_target_temperature_step above), so a
-        # fractional value (e.g. converted from Fahrenheit) would otherwise
-        # be silently ignored by the hardware.
-        temperature = round(temperature)
-
         await self._set_device_params(
-            {AC_TEMPERATURE_TARGET: round(temperature * 10)},
+            encode_ac_target_temperature(
+                temperature,
+                self._get_device_params().get(AC_TEMPERATURE_UNIT),
+            ),
             debounce_seconds=SET_TEMPERATURE_DEBOUNCE_SECONDS,
         )
 

--- a/custom_components/aux_cloud/const.py
+++ b/custom_components/aux_cloud/const.py
@@ -65,3 +65,12 @@ PLATFORMS = [
 ]
 
 MAX_FAILED_POLLS = 5
+
+# How long (in seconds) an optimistically-set parameter is protected from being
+# overwritten by a stale/echoed value coming back from a cloud poll. The AUX
+# cloud (and the physical device) can take a few seconds to actually apply a
+# command and report the new state, so a poll that happens right after a
+# "set" call can still return the old value. Without this grace period the
+# UI would flicker/revert to the previous value even though the command was
+# accepted (see https://github.com/maeek/ha-aux-cloud/issues/53).
+OPTIMISTIC_GRACE_PERIOD_SECONDS = 15

--- a/custom_components/aux_cloud/const.py
+++ b/custom_components/aux_cloud/const.py
@@ -74,3 +74,10 @@ MAX_FAILED_POLLS = 5
 # UI would flicker/revert to the previous value even though the command was
 # accepted (see https://github.com/maeek/ha-aux-cloud/issues/53).
 OPTIMISTIC_GRACE_PERIOD_SECONDS = 15
+
+# How long (in seconds) to wait after a temperature change before actually
+# sending it to AUX Cloud. Rapid successive changes (dragging a slider,
+# repeatedly tapping +/-) each cancel and replace the pending send, so only
+# the final value is sent - avoiding a burst of overlapping API calls that
+# can race with each other on the cloud/device side.
+SET_TEMPERATURE_DEBOUNCE_SECONDS = 0.6

--- a/custom_components/aux_cloud/temperature.py
+++ b/custom_components/aux_cloud/temperature.py
@@ -1,0 +1,62 @@
+"""AUX air-conditioner target-temperature encoding helpers."""
+
+from decimal import Decimal, ROUND_HALF_UP
+
+from .api.const import (
+    AC_TEMPERATURE_CONVERT,
+    AC_TEMPERATURE_TARGET,
+    AC_TEMPERATURE_UNIT,
+)
+
+
+AUX_TEMPERATURE_UNIT_FAHRENHEIT = 2
+
+
+def decode_ac_target_temperature(params: dict) -> float | None:
+    """Decode an AUX target temperature into the device's native unit.
+
+    Fahrenheit-mode AUX units split their Celsius-tenths representation across
+    ``temp`` and ``ac_tempconvert``. The physical unit and AC Freedom display
+    the nearest whole Fahrenheit degree represented by that pair.
+    """
+    raw_temp = params.get(AC_TEMPERATURE_TARGET)
+    if raw_temp is None:
+        return None
+
+    if params.get(AC_TEMPERATURE_UNIT) != AUX_TEMPERATURE_UNIT_FAHRENHEIT:
+        return raw_temp / 10
+
+    # AUX may return a non-zero ones digit in ``temp``. AC Freedom discards it
+    # before appending ``ac_tempconvert``.
+    converted_tenths_celsius = (
+        (int(raw_temp) // 10) * 10
+        + int(params.get(AC_TEMPERATURE_CONVERT, 0) or 0)
+    )
+
+    # Exact positive-number equivalent of AC Freedom's HALF_UP rounding of
+    # (C * 1.8) + 32, without introducing binary floating-point edge cases.
+    return 32 + (converted_tenths_celsius * 9 + 25) // 50
+
+
+def encode_ac_target_temperature(temperature: float, temp_unit: int | None) -> dict:
+    """Encode a target in the device's native unit using AUX's wire format."""
+    if temp_unit != AUX_TEMPERATURE_UNIT_FAHRENHEIT:
+        # Celsius-mode devices advertise whole-degree setpoints.
+        return {AC_TEMPERATURE_TARGET: round(temperature) * 10}
+
+    fahrenheit = int(
+        Decimal(str(temperature)).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    )
+
+    # This mirrors AC Freedom: convert the selected integer Fahrenheit value
+    # to tenths Celsius with RoundingMode.DOWN, then split the final digit into
+    # ac_tempconvert.
+    converted_tenths_celsius = (fahrenheit - 32) * 50 // 9
+    raw_temp = (converted_tenths_celsius // 10) * 10
+    temp_convert = converted_tenths_celsius % 10
+
+    return {
+        AC_TEMPERATURE_UNIT: AUX_TEMPERATURE_UNIT_FAHRENHEIT,
+        AC_TEMPERATURE_TARGET: raw_temp,
+        AC_TEMPERATURE_CONVERT: temp_convert,
+    }

--- a/custom_components/aux_cloud/util.py
+++ b/custom_components/aux_cloud/util.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from typing import Any
 
@@ -169,6 +170,10 @@ class BaseEntity(CoordinatorEntity):
             self._device_id,
             initial_params,
         )
+        # Tracks in-flight debounced sends, keyed by the sorted tuple of param
+        # names being set, so unrelated params (e.g. temp vs swing) debounce
+        # independently.
+        self._pending_debounce_tasks: dict[tuple, asyncio.Task] = {}
 
     @property
     def unique_id(self) -> str | None:
@@ -221,8 +226,19 @@ class BaseEntity(CoordinatorEntity):
         """Get device parameters securely from the state helper."""
         return self._state_helper.current_params
 
-    async def _set_device_params(self, params: dict[str, Any]):
-        """Set parameters on the device using Optimistic Updates via Helper."""
+    async def _set_device_params(
+        self, params: dict[str, Any], debounce_seconds: float = 0
+    ):
+        """Set parameters on the device using Optimistic Updates via Helper.
+
+        If debounce_seconds > 0, the optimistic update/UI write happens
+        immediately, but the actual network call is delayed by that many
+        seconds and cancelled/replaced if another call for the same set of
+        params comes in before it fires. This avoids sending one API call
+        per rapid successive change (e.g. dragging a slider or repeatedly
+        tapping +/-), which can otherwise race with itself against AUX
+        Cloud/the device.
+        """
         device_name = self._device.get("friendlyName", self._device_id)
         _LOGGER.debug("Optimistically setting %s for device %s", params, device_name)
 
@@ -230,6 +246,41 @@ class BaseEntity(CoordinatorEntity):
         self._state_helper.apply_optimistic(params)
         self.async_write_ha_state()
 
+        debounce_key = tuple(sorted(params.keys()))
+        pending_task = self._pending_debounce_tasks.get(debounce_key)
+        if pending_task and not pending_task.done():
+            pending_task.cancel()
+
+        if debounce_seconds <= 0:
+            await self._send_device_params(params, device_name)
+            return
+
+        self._pending_debounce_tasks[debounce_key] = self.hass.async_create_task(
+            self._debounced_send_device_params(
+                params, device_name, debounce_seconds, debounce_key
+            )
+        )
+
+    async def _debounced_send_device_params(
+        self,
+        params: dict[str, Any],
+        device_name: str,
+        debounce_seconds: float,
+        debounce_key: tuple,
+    ):
+        """Wait for the debounce window to elapse, then send the params."""
+        try:
+            await asyncio.sleep(debounce_seconds)
+        except asyncio.CancelledError:
+            return
+
+        try:
+            await self._send_device_params(params, device_name)
+        finally:
+            self._pending_debounce_tasks.pop(debounce_key, None)
+
+    async def _send_device_params(self, params: dict[str, Any], device_name: str):
+        """Send params to the device, rolling back the optimistic update on failure."""
         try:
             await self.coordinator.api.set_device_params(self._device, params)
             # Refresh coordinator to sync all dependent entities immediately after a successful write

--- a/custom_components/aux_cloud/util.py
+++ b/custom_components/aux_cloud/util.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any
 
 from homeassistant.core import callback
@@ -5,7 +6,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api.const import AuxProducts
-from .const import _LOGGER, DOMAIN, MANUFACTURER
+from .const import _LOGGER, DOMAIN, MANUFACTURER, OPTIMISTIC_GRACE_PERIOD_SECONDS
 
 
 class DeviceStateHelper:
@@ -18,6 +19,10 @@ class DeviceStateHelper:
         self._backup_params: dict[str, Any] = {}
         self._last_logged_payload: str | None = None
         self._last_processed_update_id: int | None = None
+        # Params that were just set optimistically, keyed by param name, value is
+        # (expected_value, expiry_monotonic_time). Used to protect optimistic
+        # updates from being clobbered by stale polls right after a "set" call.
+        self._pending_optimistic: dict[str, tuple[Any, float]] = {}
 
     @property
     def current_params(self) -> dict[str, Any]:
@@ -83,16 +88,53 @@ class DeviceStateHelper:
             )
 
         self._failed_poll_count = 0
-        self._cached_params.update(current_params)
+
+        if not self._pending_optimistic:
+            self._cached_params.update(current_params)
+            return
+
+        now = time.monotonic()
+        for key, value in current_params.items():
+            pending = self._pending_optimistic.get(key)
+
+            if pending is None:
+                self._cached_params[key] = value
+                continue
+
+            expected_value, expiry = pending
+
+            if value == expected_value:
+                # Cloud confirmed our optimistic value.
+                self._cached_params[key] = value
+                self._pending_optimistic.pop(key, None)
+            elif now < expiry:
+                # Likely a stale echo from before the command was applied.
+                # Keep the optimistic value and wait for confirmation.
+                _LOGGER.debug(
+                    "Ignoring stale value for %s on device %s: got %s, expected %s",
+                    key, device_name, value, expected_value,
+                )
+            else:
+                # Grace period expired without confirmation, e.g. the command
+                # was rejected or overridden elsewhere. Trust the cloud value.
+                _LOGGER.debug(
+                    "Optimistic update for %s on device %s not confirmed in time, "
+                    "reverting to reported value %s",
+                    key, device_name, value,
+                )
+                self._cached_params[key] = value
+                self._pending_optimistic.pop(key, None)
 
     def apply_optimistic(self, new_params: dict[str, Any]):
         """Applies new params optimistically and saves a backup for rollback."""
         self._backup_params.clear()
+        expiry = time.monotonic() + OPTIMISTIC_GRACE_PERIOD_SECONDS
 
         for key, value in new_params.items():
             if key in self._cached_params:
                 self._backup_params[key] = self._cached_params[key]
             self._cached_params[key] = value
+            self._pending_optimistic[key] = (value, expiry)
 
         self._last_logged_payload = None
 
@@ -103,6 +145,7 @@ class DeviceStateHelper:
                 self._cached_params[key] = self._backup_params[key]
             else:
                 self._cached_params.pop(key, None)
+            self._pending_optimistic.pop(key, None)
         self._backup_params.clear()
         self._last_logged_payload = None
 

--- a/docs/dev/live_fix_test.py
+++ b/docs/dev/live_fix_test.py
@@ -1,0 +1,123 @@
+"""Live test against a real AUX Cloud account/device.
+
+Mimics exactly what the Home Assistant integration does when you change the
+target temperature:
+
+  1. Optimistically apply the new value locally (DeviceStateHelper.apply_optimistic)
+  2. Send the "set" command to AUX Cloud (AuxCloudAPI.set_device_params)
+  3. Immediately poll fresh params from the cloud (AuxCloudAPI.get_device_params),
+     exactly like coordinator.async_request_refresh() would trigger
+  4. Feed that poll into DeviceStateHelper.process_new_payload() and check
+     whether the optimistic value survived the (possibly stale) poll.
+
+Not committed to git - reads credentials from docs/dev/config.yaml (gitignored).
+"""
+
+import asyncio
+import os
+import pathlib
+import pprint
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
+
+from custom_components.aux_cloud.api.aux_cloud import AuxCloudAPI
+from custom_components.aux_cloud.api.const import AC_TEMPERATURE_TARGET
+from custom_components.aux_cloud.util import DeviceStateHelper
+
+
+def get_config_path():
+    current_dir = pathlib.Path(__file__).parent
+    return os.path.join(current_dir, "config.yaml")
+
+
+async def main():
+    with open(get_config_path(), "r", encoding="utf-8") as f:
+        config = yaml.load(f, Loader=yaml.FullLoader)
+
+    email = config["email"]
+    password = config["password"]
+    shared = config.get("shared", False)
+    region = config.get("region", "eu")
+
+    cloud = AuxCloudAPI(region=region)
+    print(f"Logging in (region={region})...")
+    await cloud.login(email, password)
+
+    families = await cloud.get_families()
+    if not families:
+        print("No families found on this account.")
+        return
+
+    all_devices = []
+    for family in families:
+        devices = await cloud.get_devices(family["familyid"], shared=shared)
+        all_devices.extend(devices or [])
+
+    if not all_devices:
+        print("No devices found.")
+        return
+
+    print(f"\nFound {len(all_devices)} device(s):")
+    for i, dev in enumerate(all_devices):
+        print(f"  [{i}] {dev.get('friendlyName')} ({dev.get('endpointId')})")
+
+    device = all_devices[0]
+    print(f"\nUsing device: {device.get('friendlyName')}")
+
+    current_params = device.get("params", {})
+    print("\nCurrent params:")
+    pprint.pprint(current_params)
+
+    current_temp = current_params.get(AC_TEMPERATURE_TARGET)
+    if current_temp is None:
+        print(f"\nDevice has no '{AC_TEMPERATURE_TARGET}' param, cannot test.")
+        return
+
+    current_temp_c = current_temp / 10
+    # Bump target temp by 1C (wrap if it would go out of a sane AC range).
+    new_temp_c = current_temp_c + 1 if current_temp_c < 30 else current_temp_c - 1
+    new_temp = int(new_temp_c * 10)
+
+    print(f"\nCurrent target temp: {current_temp_c}C")
+    print(f"Will set target temp: {new_temp_c}C")
+
+    # --- Mirror exactly what BaseEntity._set_device_params() does ---
+    helper = DeviceStateHelper(current_params, max_failed_polls=5)
+
+    print("\n[1] Applying optimistic update locally...")
+    helper.apply_optimistic({AC_TEMPERATURE_TARGET: new_temp})
+    print(f"    Local cached target temp is now: {helper.current_params[AC_TEMPERATURE_TARGET] / 10}C")
+
+    print("\n[2] Sending 'set' command to AUX Cloud...")
+    await cloud.set_device_params(device, {AC_TEMPERATURE_TARGET: new_temp})
+    print("    Set command sent.")
+
+    print("\n[3] Immediately polling fresh params from the cloud (like async_request_refresh)...")
+    fresh_params = await cloud.get_device_params(device, params=[])
+    print(f"    Cloud reported target temp: {fresh_params.get(AC_TEMPERATURE_TARGET, 'N/A')}")
+
+    print("\n[4] Feeding poll result into DeviceStateHelper.process_new_payload()...")
+    helper.process_new_payload(fresh_params, device.get("friendlyName", "AC"), update_id=1)
+    result_temp = helper.current_params.get(AC_TEMPERATURE_TARGET)
+    print(f"    Local cached target temp after poll: {result_temp / 10 if result_temp is not None else 'N/A'}C")
+
+    if result_temp == new_temp:
+        print("\n>>> PASS: Optimistic value held (either confirmed or protected from stale echo).")
+    else:
+        print(f"\n>>> FAIL: Value reverted to {result_temp / 10}C instead of staying at {new_temp_c}C!")
+
+    # Give the real device a few seconds, then poll again to see convergence.
+    print("\nWaiting 5s then polling again to check real device convergence...")
+    await asyncio.sleep(5)
+    fresh_params_2 = await cloud.get_device_params(device, params=[])
+    print(f"Cloud reported target temp after 5s: {fresh_params_2.get(AC_TEMPERATURE_TARGET, 'N/A')}")
+    helper.process_new_payload(fresh_params_2, device.get("friendlyName", "AC"), update_id=2)
+    result_temp_2 = helper.current_params.get(AC_TEMPERATURE_TARGET)
+    print(f"Local cached target temp after 2nd poll: {result_temp_2 / 10 if result_temp_2 is not None else 'N/A'}C")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/dev/live_fix_test_rapid.py
+++ b/docs/dev/live_fix_test_rapid.py
@@ -1,0 +1,84 @@
+"""Rapid-fire live test: set -> poll immediately (no sleep) in a tight loop to
+try to catch the AUX cloud returning a stale/pre-command value, and confirm the
+DeviceStateHelper's optimistic protection holds the correct value regardless.
+
+Not committed to git - reads credentials from docs/dev/config.yaml (gitignored).
+"""
+
+import asyncio
+import os
+import pathlib
+import sys
+
+import yaml
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
+
+from custom_components.aux_cloud.api.aux_cloud import AuxCloudAPI
+from custom_components.aux_cloud.api.const import AC_TEMPERATURE_TARGET
+from custom_components.aux_cloud.util import DeviceStateHelper
+
+
+def get_config_path():
+    current_dir = pathlib.Path(__file__).parent
+    return os.path.join(current_dir, "config.yaml")
+
+
+async def main():
+    with open(get_config_path(), "r", encoding="utf-8") as f:
+        config = yaml.load(f, Loader=yaml.FullLoader)
+
+    email = config["email"]
+    password = config["password"]
+    shared = config.get("shared", False)
+    region = config.get("region", "eu")
+
+    cloud = AuxCloudAPI(region=region)
+    await cloud.login(email, password)
+
+    families = await cloud.get_families()
+    all_devices = []
+    for family in families:
+        devices = await cloud.get_devices(family["familyid"], shared=shared)
+        all_devices.extend(devices or [])
+
+    device = all_devices[0]
+    print(f"Using device: {device.get('friendlyName')}")
+
+    current_temp = device["params"][AC_TEMPERATURE_TARGET]
+    helper = DeviceStateHelper(device["params"], max_failed_polls=5)
+
+    temps_c = [23.0, 24.0, 22.0, 25.0, 23.0]
+    stale_hits = 0
+
+    for temp_c in temps_c:
+        new_temp = int(temp_c * 10)
+        print(f"\nSetting target temp -> {temp_c}C")
+        helper.apply_optimistic({AC_TEMPERATURE_TARGET: new_temp})
+
+        await cloud.set_device_params(device, {AC_TEMPERATURE_TARGET: new_temp})
+
+        # Immediately poll with no delay at all - worst case race.
+        fresh_params = await cloud.get_device_params(device, params=[])
+        raw_cloud_val = fresh_params.get(AC_TEMPERATURE_TARGET)
+        print(f"  Raw cloud value immediately after set: {raw_cloud_val / 10 if raw_cloud_val is not None else 'N/A'}C")
+
+        if raw_cloud_val != new_temp:
+            stale_hits += 1
+            print("  -> STALE ECHO DETECTED from cloud (this is exactly what used to cause the revert bug)")
+
+        helper.process_new_payload(fresh_params, device.get("friendlyName", "AC"), update_id=id(fresh_params))
+        result = helper.current_params.get(AC_TEMPERATURE_TARGET)
+        held = result == new_temp
+        print(f"  Helper's cached value after feeding poll: {result / 10}C -> {'HELD correctly' if held else 'REVERTED (BUG)'}")
+
+        if not held:
+            print("  !!! FIX FAILED TO PROTECT VALUE !!!")
+
+    print(f"\nStale cloud echoes observed: {stale_hits}/{len(temps_c)}")
+    print("Restoring original temp...")
+    await cloud.set_device_params(device, {AC_TEMPERATURE_TARGET: current_temp})
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_aux_cloud.py
+++ b/tests/test_aux_cloud.py
@@ -1,14 +1,18 @@
 """Tests for the AuxCloudAPI class."""
 
+import base64
+import json
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
 
 from custom_components.aux_cloud.api.aux_cloud import (
+    AuxApiError,
     AuxCloudAPI,
     API_SERVER_URL_EU,
     API_SERVER_URL_USA,
     API_SERVER_URL_CN,
+    MAX_ACT_DEVICE_RETRIES,
 )
 
 
@@ -67,3 +71,93 @@ class TestAuxCloudAPI:
         # With additional kwargs
         headers = aux_api._get_headers(custom_header="custom_value")
         assert headers["custom_header"] == "custom_value"
+
+
+@pytest.fixture
+def mock_device():
+    """Return a minimal device dict accepted by _act_device_params."""
+    cookie = base64.b64encode(
+        json.dumps({"terminalid": "term1", "aeskey": "key1"}).encode()
+    ).decode()
+    return {
+        "endpointId": "device1",
+        "productId": "000000000000000000000000c0620000",
+        "cookie": cookie,
+        "devSession": "session1",
+        "mac": "00:00:00:00:00:00",
+        "devicetypeFlag": 0,
+    }
+
+
+def _error_response(error_type: str) -> dict:
+    return {
+        "event": {
+            "header": {"name": "ErrorResponse"},
+            "payload": {"type": error_type, "message": "endpoint unreachable"},
+        }
+    }
+
+
+def _success_response(params: dict) -> dict:
+    return {
+        "event": {
+            "header": {"name": "Response"},
+            "payload": {
+                "data": json.dumps(
+                    {
+                        "params": list(params.keys()),
+                        "vals": [[{"val": v}] for v in params.values()],
+                    }
+                )
+            },
+        }
+    }
+
+
+class TestAuxCloudApiRetry:
+    """Tests for the retry-on-transient-network-timeout behavior."""
+
+    @pytest.fixture(autouse=True)
+    def no_sleep(self, monkeypatch):
+        """Avoid real delays between retries in tests."""
+        monkeypatch.setattr(
+            "custom_components.aux_cloud.api.aux_cloud.asyncio.sleep",
+            AsyncMock(return_value=None),
+        )
+
+    async def test_retries_on_network_timeout_then_succeeds(self, aux_api, mock_device):
+        """A transient NETWORK_TIME_OUT should be retried and can still succeed."""
+        aux_api._make_request = AsyncMock(
+            side_effect=[
+                _error_response("NETWORK_TIME_OUT"),
+                _error_response("NETWORK_TIME_OUT"),
+                _success_response({"temp": 238}),
+            ]
+        )
+
+        result = await aux_api.set_device_params(mock_device, {"temp": 238})
+
+        assert result == {"temp": 238}
+        assert aux_api._make_request.call_count == 3
+
+    async def test_gives_up_after_max_retries(self, aux_api, mock_device):
+        """Persistent NETWORK_TIME_OUT errors should eventually raise."""
+        aux_api._make_request = AsyncMock(
+            return_value=_error_response("NETWORK_TIME_OUT")
+        )
+
+        with pytest.raises(AuxApiError):
+            await aux_api.set_device_params(mock_device, {"temp": 238})
+
+        assert aux_api._make_request.call_count == MAX_ACT_DEVICE_RETRIES + 1
+
+    async def test_non_retryable_error_fails_immediately(self, aux_api, mock_device):
+        """A non-timeout error should not be retried."""
+        aux_api._make_request = AsyncMock(
+            return_value=_error_response("SOME_OTHER_ERROR")
+        )
+
+        with pytest.raises(AuxApiError):
+            await aux_api.set_device_params(mock_device, {"temp": 238})
+
+        assert aux_api._make_request.call_count == 1

--- a/tests/test_aux_cloud_coordinator.py
+++ b/tests/test_aux_cloud_coordinator.py
@@ -1,5 +1,6 @@
 """Test AUX Cloud coordinator functionality."""
 
+import time
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
@@ -177,3 +178,52 @@ def test_state_helper_deduplicates_same_update_id(coordinator):
         helper.process_new_payload({}, "AC Unit 1", update_id=update_id)
 
     assert helper.is_available() is False
+
+
+def test_state_helper_optimistic_update_survives_stale_poll(coordinator):
+    """A poll returning the pre-set value right after a set should not revert it.
+
+    Regression test for https://github.com/maeek/ha-aux-cloud/issues/53 where
+    the reported temperature would jump back to the previous value shortly
+    after being changed, because a poll triggered right after the "set" call
+    raced with the device/cloud actually applying the change.
+    """
+    helper = coordinator.get_state_helper("device1", {"temp": 220})
+
+    helper.apply_optimistic({"temp": 240})
+    assert helper.current_params["temp"] == 240
+
+    # A poll that races the "set" call and returns the stale value.
+    helper.process_new_payload({"temp": 220}, "AC Unit 1", update_id=1)
+    assert helper.current_params["temp"] == 240
+
+    # A later poll confirms the device actually applied the change.
+    helper.process_new_payload({"temp": 240}, "AC Unit 1", update_id=2)
+    assert helper.current_params["temp"] == 240
+
+
+def test_state_helper_optimistic_update_expires_without_confirmation(coordinator):
+    """If the cloud never confirms the optimistic value, trust the poll."""
+    helper = coordinator.get_state_helper("device1", {"temp": 220})
+
+    helper.apply_optimistic({"temp": 240})
+    # Force the grace period to have already elapsed.
+    helper._pending_optimistic["temp"] = (240, time.monotonic() - 1)
+
+    helper.process_new_payload({"temp": 220}, "AC Unit 1", update_id=1)
+    assert helper.current_params["temp"] == 220
+
+
+def test_state_helper_rollback_clears_pending_optimistic(coordinator):
+    """Rolling back a failed set should also clear the pending protection."""
+    helper = coordinator.get_state_helper("device1", {"temp": 220})
+
+    helper.apply_optimistic({"temp": 240})
+    helper.rollback({"temp": 240})
+
+    assert helper.current_params["temp"] == 220
+    assert "temp" not in helper._pending_optimistic
+
+    # A subsequent poll should be applied normally now.
+    helper.process_new_payload({"temp": 220}, "AC Unit 1", update_id=1)
+    assert helper.current_params["temp"] == 220

--- a/tests/test_climate_temperature.py
+++ b/tests/test_climate_temperature.py
@@ -1,4 +1,4 @@
-"""Tests for AC target temperature handling: whole-degree rounding and debounce.
+"""Tests for AUX AC target-temperature encoding and debounce behavior.
 
 These deliberately avoid the pytest_homeassistant_custom_component `hass`
 fixture (which needs a real event loop) so they stay fast and lightweight -
@@ -10,8 +10,14 @@ from unittest.mock import MagicMock, AsyncMock
 
 import pytest
 from homeassistant.components.climate import ClimateEntityDescription
+from homeassistant.const import UnitOfTemperature
 
-from custom_components.aux_cloud.api.const import AC_TEMPERATURE_TARGET
+from custom_components.aux_cloud.api.const import (
+    AC_TEMPERATURE_AMBIENT,
+    AC_TEMPERATURE_CONVERT,
+    AC_TEMPERATURE_TARGET,
+    AC_TEMPERATURE_UNIT,
+)
 from custom_components.aux_cloud.climate import AuxACClimateEntity
 from custom_components.aux_cloud.const import SET_TEMPERATURE_DEBOUNCE_SECONDS
 from custom_components.aux_cloud.util import DeviceStateHelper
@@ -48,8 +54,21 @@ class FakeCoordinator:
         return self._helper
 
 
-def make_ac_entity(initial_temp_tenths=200):
-    coordinator = FakeCoordinator({AC_TEMPERATURE_TARGET: initial_temp_tenths})
+def make_ac_entity(
+    initial_temp_tenths=200,
+    tempunit=None,
+    temp_convert=None,
+    ambient_temp_tenths=None,
+):
+    initial_params = {AC_TEMPERATURE_TARGET: initial_temp_tenths}
+    if tempunit is not None:
+        initial_params[AC_TEMPERATURE_UNIT] = tempunit
+    if temp_convert is not None:
+        initial_params[AC_TEMPERATURE_CONVERT] = temp_convert
+    if ambient_temp_tenths is not None:
+        initial_params[AC_TEMPERATURE_AMBIENT] = ambient_temp_tenths
+
+    coordinator = FakeCoordinator(initial_params)
     entity = AuxACClimateEntity(
         coordinator, "device1", ClimateEntityDescription(key="ac", name="AC")
     )
@@ -58,17 +77,17 @@ def make_ac_entity(initial_temp_tenths=200):
     return entity, coordinator
 
 
-class TestWholeDegreeRounding:
-    """The device only accepts whole-Celsius-degree setpoints."""
+class TestCelsiusEncoding:
+    """Celsius-mode devices accept whole-Celsius-degree setpoints."""
 
     @pytest.mark.parametrize(
         "celsius_input,expected_tenths",
         [
-            (20.0, 200),  # 68F equivalent - already whole
-            (22.777777777777779, 230),  # ~73F - rounds down to 23C
-            (23.333333333333332, 230),  # ~74F - rounds down to 23C (same as 73F!)
-            (23.888888888888889, 240),  # ~75F - rounds up to 24C
-            (25.0, 250),  # 77F equivalent - already whole
+            (20.0, 200),
+            (22.777777777777779, 230),
+            (23.333333333333332, 230),
+            (23.888888888888889, 240),
+            (25.0, 250),
         ],
     )
     async def test_set_temperature_snaps_to_whole_degree(
@@ -84,6 +103,42 @@ class TestWholeDegreeRounding:
         sent_params = coordinator.api.set_device_params.call_args[0][1]
         assert sent_params == {AC_TEMPERATURE_TARGET: expected_tenths}
         assert sent_params[AC_TEMPERATURE_TARGET] % 10 == 0
+
+
+class TestFahrenheitEncoding:
+    """Fahrenheit-mode devices use temp and ac_tempconvert together."""
+
+    def test_target_temperature_decodes_to_exact_displayed_fahrenheit(self):
+        entity, _ = make_ac_entity(
+            initial_temp_tenths=240,
+            tempunit=2,
+            temp_convert=2,
+            ambient_temp_tenths=236,
+        )
+
+        assert entity.target_temperature == 76
+        assert entity.current_temperature == pytest.approx(74.48)
+        assert entity.temperature_unit == UnitOfTemperature.FAHRENHEIT
+        assert entity.min_temp == 60
+        assert entity.max_temp == 90
+        assert entity.target_temperature_step == 1
+
+    async def test_set_temperature_sends_ac_freedom_wire_format(self):
+        entity, coordinator = make_ac_entity(
+            initial_temp_tenths=240,
+            tempunit=2,
+            temp_convert=2,
+        )
+
+        await entity.async_set_temperature(temperature=76)
+        await asyncio.sleep(SET_TEMPERATURE_DEBOUNCE_SECONDS + 0.2)
+
+        sent_params = coordinator.api.set_device_params.call_args[0][1]
+        assert sent_params == {
+            AC_TEMPERATURE_UNIT: 2,
+            AC_TEMPERATURE_TARGET: 240,
+            AC_TEMPERATURE_CONVERT: 4,
+        }
 
 
 class TestSetTemperatureDebounce:

--- a/tests/test_climate_temperature.py
+++ b/tests/test_climate_temperature.py
@@ -1,0 +1,116 @@
+"""Tests for AC target temperature handling: whole-degree rounding and debounce.
+
+These deliberately avoid the pytest_homeassistant_custom_component `hass`
+fixture (which needs a real event loop) so they stay fast and lightweight -
+they only need a fake hass/coordinator that quacks like the real thing.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+from homeassistant.components.climate import ClimateEntityDescription
+
+from custom_components.aux_cloud.api.const import AC_TEMPERATURE_TARGET
+from custom_components.aux_cloud.climate import AuxACClimateEntity
+from custom_components.aux_cloud.const import SET_TEMPERATURE_DEBOUNCE_SECONDS
+from custom_components.aux_cloud.util import DeviceStateHelper
+
+
+class FakeHass:
+    """Minimal stand-in for HomeAssistant that just runs background tasks."""
+
+    def async_create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+
+class FakeCoordinator:
+    """Minimal stand-in for AuxCloudCoordinator."""
+
+    def __init__(self, initial_params: dict):
+        self.api = MagicMock()
+        self.api.set_device_params = AsyncMock(return_value={})
+        self.async_request_refresh = AsyncMock()
+        self._device = {
+            "endpointId": "device1",
+            "friendlyName": "Living Room Mini split",
+            "productId": "000000000000000000000000c0620000",
+            "params": initial_params,
+        }
+        self._helper = None
+
+    def get_device_by_endpoint_id(self, device_id):
+        return self._device
+
+    def get_state_helper(self, device_id, initial_params):
+        if self._helper is None:
+            self._helper = DeviceStateHelper(initial_params, max_failed_polls=5)
+        return self._helper
+
+
+def make_ac_entity(initial_temp_tenths=200):
+    coordinator = FakeCoordinator({AC_TEMPERATURE_TARGET: initial_temp_tenths})
+    entity = AuxACClimateEntity(
+        coordinator, "device1", ClimateEntityDescription(key="ac", name="AC")
+    )
+    entity.hass = FakeHass()
+    entity.async_write_ha_state = MagicMock()
+    return entity, coordinator
+
+
+class TestWholeDegreeRounding:
+    """The device only accepts whole-Celsius-degree setpoints."""
+
+    @pytest.mark.parametrize(
+        "celsius_input,expected_tenths",
+        [
+            (20.0, 200),  # 68F equivalent - already whole
+            (22.777777777777779, 230),  # ~73F - rounds down to 23C
+            (23.333333333333332, 230),  # ~74F - rounds down to 23C (same as 73F!)
+            (23.888888888888889, 240),  # ~75F - rounds up to 24C
+            (25.0, 250),  # 77F equivalent - already whole
+        ],
+    )
+    async def test_set_temperature_snaps_to_whole_degree(
+        self, celsius_input, expected_tenths
+    ):
+        entity, coordinator = make_ac_entity()
+
+        await entity.async_set_temperature(temperature=celsius_input)
+        # Let the debounced send fire.
+        await asyncio.sleep(SET_TEMPERATURE_DEBOUNCE_SECONDS + 0.2)
+
+        coordinator.api.set_device_params.assert_called_once()
+        sent_params = coordinator.api.set_device_params.call_args[0][1]
+        assert sent_params == {AC_TEMPERATURE_TARGET: expected_tenths}
+        assert sent_params[AC_TEMPERATURE_TARGET] % 10 == 0
+
+
+class TestSetTemperatureDebounce:
+    """Rapid successive calls should collapse into a single network send."""
+
+    async def test_rapid_calls_send_only_final_value(self):
+        entity, coordinator = make_ac_entity()
+
+        for celsius in [23.3, 25.2, 24.7, 25.0, 23.3]:
+            await entity.async_set_temperature(temperature=celsius)
+            await asyncio.sleep(0.05)  # faster than the debounce window
+
+        assert coordinator.api.set_device_params.call_count == 0
+
+        await asyncio.sleep(SET_TEMPERATURE_DEBOUNCE_SECONDS + 0.3)
+
+        assert coordinator.api.set_device_params.call_count == 1
+        sent_params = coordinator.api.set_device_params.call_args[0][1]
+        # Last requested value was 23.3C -> rounds to 23C -> 230
+        assert sent_params == {AC_TEMPERATURE_TARGET: 230}
+
+    async def test_single_call_still_sends_after_debounce_window(self):
+        entity, coordinator = make_ac_entity()
+
+        await entity.async_set_temperature(temperature=25.0)
+        assert coordinator.api.set_device_params.call_count == 0
+
+        await asyncio.sleep(SET_TEMPERATURE_DEBOUNCE_SECONDS + 0.3)
+
+        assert coordinator.api.set_device_params.call_count == 1

--- a/tests/test_temperature_encoding.py
+++ b/tests/test_temperature_encoding.py
@@ -1,0 +1,77 @@
+"""Tests for AUX air-conditioner target-temperature encoding."""
+
+import pytest
+
+from custom_components.aux_cloud.api.const import (
+    AC_TEMPERATURE_CONVERT,
+    AC_TEMPERATURE_TARGET,
+    AC_TEMPERATURE_UNIT,
+)
+from custom_components.aux_cloud.temperature import (
+    decode_ac_target_temperature,
+    encode_ac_target_temperature,
+)
+
+
+@pytest.mark.parametrize(
+    ("fahrenheit", "raw_temp", "temp_convert"),
+    [
+        (72, 220, 0),
+        (73, 220, 7),
+        (74, 230, 2),
+        (75, 230, 7),
+        (76, 240, 2),
+        (77, 250, 0),
+        (78, 255, 5),
+    ],
+)
+def test_decode_captured_fahrenheit_device_values(
+    fahrenheit, raw_temp, temp_convert
+):
+    """Decode values captured after matching AC Freedom/display setpoints."""
+    decoded = decode_ac_target_temperature(
+        {
+            AC_TEMPERATURE_TARGET: raw_temp,
+            AC_TEMPERATURE_UNIT: 2,
+            AC_TEMPERATURE_CONVERT: temp_convert,
+        }
+    )
+
+    assert decoded == fahrenheit
+
+
+@pytest.mark.parametrize(
+    ("fahrenheit", "raw_temp", "temp_convert"),
+    [
+        (72, 220, 2),
+        (73, 220, 7),
+        (74, 230, 3),
+        (75, 230, 8),
+        (76, 240, 4),
+        (77, 250, 0),
+        (78, 250, 5),
+    ],
+)
+def test_encode_fahrenheit_matches_ac_freedom(
+    fahrenheit, raw_temp, temp_convert
+):
+    """Mirror AC Freedom's DOWN-rounded split wire representation."""
+    assert encode_ac_target_temperature(fahrenheit, 2) == {
+        AC_TEMPERATURE_UNIT: 2,
+        AC_TEMPERATURE_TARGET: raw_temp,
+        AC_TEMPERATURE_CONVERT: temp_convert,
+    }
+
+
+def test_celsius_device_encoding_is_unchanged():
+    """Keep the existing whole-Celsius behavior for non-Fahrenheit devices."""
+    assert encode_ac_target_temperature(23.3, 1) == {
+        AC_TEMPERATURE_TARGET: 230
+    }
+    assert decode_ac_target_temperature(
+        {AC_TEMPERATURE_TARGET: 235, AC_TEMPERATURE_UNIT: 1}
+    ) == 23.5
+
+
+def test_missing_target_temperature_decodes_to_none():
+    assert decode_ac_target_temperature({AC_TEMPERATURE_UNIT: 2}) is None


### PR DESCRIPTION
## Summary

- Fixes temperature setpoints reverting shortly after being set (#53).
- Root cause: after an optimistic `set`, the coordinator's immediate
  `async_request_refresh()` polls the cloud right away. The AUX cloud /
  physical device can take a few seconds to actually apply the command,
  so that immediate poll can return the *old* value, which was then
  unconditionally merged into the cached params, clobbering the
  optimistic update the UI had just shown.
- Adds a short grace period (`OPTIMISTIC_GRACE_PERIOD_SECONDS`, 15s) during
  which an optimistically-set param is protected from being overwritten by
  a stale/echoed poll value, until either the cloud confirms the new value
  or the grace period expires (in which case the cloud's reported value is
  trusted again, e.g. if the command was actually rejected).
- `DeviceStateHelper.rollback()` also clears the pending-protection state
  for params whose "set" call failed.

## Test plan

- Added unit tests in `tests/test_aux_cloud_coordinator.py`:
  - optimistic value survives a stale poll right after a set
  - optimistic value falls back to the polled value once the grace period
    expires without confirmation
  - rollback clears pending protection so subsequent polls apply normally
- Manually verified against a real AUX Cloud account/device (AC), including
  a rapid back-to-back temperature change stress test, confirming the
  optimistic value is held correctly across polls.
- `pylint custom_components/aux_cloud` still passes above the repo's
  `--fail-under=9.7` threshold.
